### PR TITLE
fix(mcp-server.sj):  delete `console.log` and `console.error` statements

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,3 @@
 
 // Import and run the MCP server
 import './src/mcp-server.js';
-
-// The server is started in the imported file
-console.log('MCP Debugger started. Connected to Node.js Inspector protocol.');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hyperdrive-eng/mcp-nodejs-debugger",
-  "version": "0.2.0",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hyperdrive-eng/mcp-nodejs-debugger",
-      "version": "0.2.0",
+      "version": "0.2.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperdrive-eng/mcp-nodejs-debugger",
-  "version": "0.3.1",
+  "version": "0.2.2",
   "description": "An MCP server to debug Node.js at runtime",
   "main": "index.js",
   "bin": "./index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperdrive-eng/mcp-nodejs-debugger",
-  "version": "0.2.1",
+  "version": "0.3.1",
   "description": "An MCP server to debug Node.js at runtime",
   "main": "index.js",
   "bin": "./index.js",

--- a/src/mcp-server.js
+++ b/src/mcp-server.js
@@ -135,7 +135,6 @@ class Inspector {
 		} catch (error) {
 			this.scheduleRetry();
     }
-		
 	}
 	
 	handleEvent(event) {

--- a/src/mcp-server.js
+++ b/src/mcp-server.js
@@ -120,7 +120,8 @@ class Inspector {
 	}
 	
 	async enableDebugger() {
-		if (!this.debuggerEnabled && this.connected) {
+    try {
+      if (!this.debuggerEnabled && this.connected) {
 
 				await this.send('Debugger.enable', {});
 				this.debuggerEnabled = true;
@@ -130,7 +131,11 @@ class Inspector {
 				
 				// Also activate possible domains we'll need
 				await this.send('Runtime.runIfWaitingForDebugger', {});
-		}
+			}
+		} catch (error) {
+			this.scheduleRetry();
+    }
+		
 	}
 	
 	handleEvent(event) {

--- a/src/mcp-server.js
+++ b/src/mcp-server.js
@@ -121,7 +121,7 @@ class Inspector {
 	
 	async enableDebugger() {
 		if (!this.debuggerEnabled && this.connected) {
-			try {
+
 				await this.send('Debugger.enable', {});
 				this.debuggerEnabled = true;
 				
@@ -130,7 +130,6 @@ class Inspector {
 				
 				// Also activate possible domains we'll need
 				await this.send('Runtime.runIfWaitingForDebugger', {});
-			}
 		}
 	}
 	


### PR DESCRIPTION
### Description

- fix(mcp-server.js): delete `console.log` and `console.error`
- fix(index.js): delete `console.log` and `console.error`

### Other changes

- chore(package.json): bump patch version from `0.2.1` to `0.2.2`

### Tested

Yes, published beta version and tried to install in Cursor: 

```json
{
  "mcpServers": {
    "nodejs-debugger": {
      "command": "npx",
      "args": ["@hyperdrive-eng/mcp-nodejs-debugger@0.3.1-beta.4"]
    }
  }
}
```

<img width="841" alt="image" src="https://github.com/user-attachments/assets/8bd38604-5bb0-4ff2-b330-d4c0f35426e7" />

Used on our test server:

```sh
node --inspect index.js
Debugger listening on ws://127.0.0.1:9229/6b913e98-c16a-48b0-bcd5-69afdd5acfcc
For help, see: https://nodejs.org/en/docs/inspector
Server running at http://localhost:3000/
Debugger attached.
```

<img width="421" alt="image" src="https://github.com/user-attachments/assets/f2cb213a-9104-4a56-bbe5-3002fcaab7ee" />

Also tested local install with 

```
npx ~/Documents/hyperdrive-eng/mcp-nodejs-debugger
```

### Related issues

- closes https://github.com/hyperdrive-eng/mcp-nodejs-debugger/issues/10

<!-- Linear magic words

1. Closing 
  1. close, closes, closed, closing fix, fixes, fixed, fixing, resolve, resolves, resolved, resolving, complete, completes, completed, completing
  2. move the issue to In Progress when the branch is pushed and Done when the commit is merged to the default branch
2. Non-closing
  1. ref, references, part of, related to, contributes to, towards
  2. will not close the issue when the PR or commit merges
-->

### Backwards compatibility

Yes, fixes bug.

### Documentation
Publish beta version with 

```
npm publish --tag beta --access public
```

I mistakenly published `0.3.1` beta versions, but in the end I only released a patch update `0.2.2` because it's a backwards compatible bug fix.