### PR TITLE
Disable debugger on WebSocket error and close

### DIFF
--- a/src/mcp-server.js
+++ b/src/mcp-server.js
@@ -72,11 +72,13 @@ class Inspector {
 			
 			this.ws.on('error', (error) => {
 				this.scheduleRetry();
+				 this.debuggerEnabled = false;
 			});
 			
 			this.ws.on('close', () => {
 				this.connected = false;
 				this.scheduleRetry();
+				this.debuggerEnabled = false;
 			});
 			
 			this.ws.on('message', (data) => {
@@ -1139,6 +1141,7 @@ server.tool(
       if (inspector.connected && inspector.ws) {
         inspector.ws.close();
         inspector.connected = false;
+		inspector.debuggerEnabled = false;
       }
       
       // Reset retry count and initialize


### PR DESCRIPTION
### Description
In case of disconnect debuggerEnabled must be set to false. 

### Tested
Breakpoints were not working correctly before the modification. Now works fine. 
